### PR TITLE
Fix for expired maven.restlet.com https cert and recent versions of m…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <repository>
       <id>maven-restlet</id>
       <name>Restlet repository</name>
-      <url>https://maven.restlet.com</url>
+      <url>https://maven.restlet.talend.com</url>
     </repository>
   </repositories>
   <properties>


### PR DESCRIPTION
…aven

Transfer failed for
https://maven.restlet.com/org/restlet/jee/org.restlet/2.4.3/org.restlet-2.4.3.pom: PKIX path validation failed: java.security.cert.CertPathValidatorException: validity check failed: NotAfter: Sun Nov 13 17:05:56 GMT 2022 -> [Help 1]

Please see:
  https://github.com/restlet/restlet-framework-java/issues/1384